### PR TITLE
PLAT3-226 set display name from additional display

### DIFF
--- a/properties/components.py
+++ b/properties/components.py
@@ -45,7 +45,7 @@ class ComponentsPropertyType(BasePropertyType):
           'id': c.get('id'),
           'componentType': c.get('componentType'),
           'componentData': c.get('componentData',{}),
-          'displayName': c.get('displayName'),
+          'displayName': display_name,
           'versionId': c.get('versionId', component.component_set_version_id),
           'componentSetId': c.get('componentSetId', component.component_set_id),
           'icon': c.get('icon')


### PR DESCRIPTION
set display name for a widget base component like it used to do in the old platform