### PR TITLE
PLAT3-2331 moved ColumnDataType to here

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,7 @@
 from .constants import EXPERIENCE_CLOUD_FACTORY, add_read_handler
 from .properties import Properties
 from .components import Components
+from .enums import ColumnDataType
 
 from .patch_request import PatchRequest
 from .property_signer import PropertySigner

--- a/enums/__init__.py
+++ b/enums/__init__.py
@@ -1,0 +1,1 @@
+from .column import ColumnDataType

--- a/enums/column.py
+++ b/enums/column.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+class ColumnDataType(str, Enum):
+  BOOLEAN = 'boolean'
+  DATETIME = 'datetime'
+  DROPDOWN = 'dropdown'
+  NUMERIC = 'numeric'
+  TEXT = 'text'
+  FILE = 'file'
+  RICHTEXT = 'richtext'
+  DOCUMENT = 'document'
+  IMAGE = 'image'
+  VIDEO = 'video'


### PR DESCRIPTION
ColumnDataType enum we use for custom columns on Data assets was previously in python-service-util, except now that we're doing row level inputs we needed a new property that can reference those columns. This repo can't access python-service-util, so its being moved here and python-service-util will point here instead.  Services should not need to be updated directly.